### PR TITLE
Fix context handling in save function

### DIFF
--- a/utils/blender/convert_bvh2mp4.py
+++ b/utils/blender/convert_bvh2mp4.py
@@ -63,8 +63,9 @@ def save(path, frame_num, viewpoint='FRONT'):
             ctx = bpy.context.copy()
             ctx['area'] = area
             ctx['region'] = area.regions[-1]
-            bpy.ops.view3d.view_selected(ctx)
-            bpy.ops.view3d.view_axis(ctx, type=viewpoint)
+            with bpy.context.temp_override(**ctx):
+                bpy.ops.view3d.view_selected()
+                bpy.ops.view3d.view_axis(type=viewpoint)
 
     # Set resolution.
     bpy.context.scene.render.resolution_x = 640


### PR DESCRIPTION
Fix #12
Fix a context handling in `convert_bvh2mp4.py` because Blender API specification has changed from version 4.0.

## Reference
- https://blender.stackexchange.com/questions/305388/valueerror-1-2-args-execution-context-is-supported-on-call-to-bpy-ops-outlin
- https://developer.blender.org/docs/release_notes/4.0/python_api/?utm_source=chatgpt.com#blender-operators-bpyops
